### PR TITLE
Enforce SPDX 2.3 SBOM path and remove 2.2 fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           set -e
 
           VERSION="${{ needs.calculate-version.outputs.version }}"
-          SBOM_OUTPUT_DIR="${{ github.workspace }}/_manifest"
+          SBOM_OUTPUT_DIR="${{ github.workspace }}"
 
           # Create output directory
           mkdir -p "$SBOM_OUTPUT_DIR"
@@ -209,11 +209,14 @@ jobs:
           }
 
           # Copy SBOM to release assets with standard naming
-          SBOM_SOURCE="$SBOM_OUTPUT_DIR/_manifest/spdx_2.2/manifest.spdx.json"
+          SBOM_SOURCE="$SBOM_OUTPUT_DIR/_manifest/spdx_2.3/manifest.spdx.json"
           SBOM_TARGET="release-assets/wt-${VERSION}-sbom.spdx.json"
 
           if [ ! -f "$SBOM_SOURCE" ]; then
             echo "::error::SBOM file not found: $SBOM_SOURCE"
+            echo "::group::SBOM Output Directory Structure"
+            ls -R "$SBOM_OUTPUT_DIR/_manifest" || true
+            echo "::endgroup::"
             exit 1
           fi
 


### PR DESCRIPTION
Update the workflow to enforce the use of SPDX 2.3 for the SBOM path, removing the fallback to 2.2. Adjust the output directory structure accordingly.