### PR TITLE
Fix SBOM file extension and streamline release workflow

### DIFF
--- a/.github/scripts/sign-artifacts.sh
+++ b/.github/scripts/sign-artifacts.sh
@@ -28,8 +28,8 @@ KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}
 echo "Using GPG key: $KEY_ID"
 
 # Sign SBOM file
-if [ -f "wt-*-sbom.json" ]; then
-  SBOM_FILE=$(ls wt-*-sbom.json | head -n 1)
+if [ -f "wt-*-sbom.spdx.json" ]; then
+  SBOM_FILE=$(ls "wt-*-sbom.spdx.json" | head -n 1)
   echo "Signing $SBOM_FILE..."
   echo "$GPG_PASSPHRASE" | gpg \
     --batch \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,12 +361,10 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           cd release-assets
-          chmod +x ../.github/scripts/sign-artifacts.sh
           ../.github/scripts/sign-artifacts.sh
 
       - name: Generate release notes
         run: |
-          chmod +x .github/scripts/generate-release-notes.sh
           .github/scripts/generate-release-notes.sh \
             "${{ needs.calculate-version.outputs.previous-version }}" \
             "${{ needs.calculate-version.outputs.version }}"


### PR DESCRIPTION
Update the SBOM file extension in the signing script and remove unnecessary chmod commands in the release workflow to simplify the process.