### PR TITLE
fix: release pipeline error

### DIFF
--- a/.github/scripts/sign-artifacts.sh
+++ b/.github/scripts/sign-artifacts.sh
@@ -28,8 +28,7 @@ KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}
 echo "Using GPG key: $KEY_ID"
 
 # Sign SBOM file
-if [ -f "wt-*-sbom.spdx.json" ]; then
-  SBOM_FILE=$(ls "wt-*-sbom.spdx.json" | head -n 1)
+if [ -f "$SBOM_FILE" ]; then
   echo "Signing $SBOM_FILE..."
   echo "$GPG_PASSPHRASE" | gpg \
     --batch \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,7 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SBOM_FILE: ${{ steps.sbom.outputs.sbom_file }}
         run: |
           cd release-assets
           ../.github/scripts/sign-artifacts.sh


### PR DESCRIPTION
Modify the sign-artifacts script to utilize the SBOM_FILE environment variable for signing, enhancing flexibility in specifying the SBOM file. Update the release workflow to pass the SBOM file as an environment variable.