### PR TITLE
fix: Enhance GPG signing process in release workflow

### DIFF
--- a/.github/scripts/sign-artifacts.sh
+++ b/.github/scripts/sign-artifacts.sh
@@ -37,6 +37,7 @@ if [ -f "$SBOM_FILE" ]; then
     --armor \
     --detach-sign \
     --default-key "$KEY_ID" \
+    --pinentry-mode loopback \
     "$SBOM_FILE"
 
   if [ -f "${SBOM_FILE}.asc" ]; then
@@ -50,8 +51,8 @@ else
 fi
 
 # Sign SHA256SUMS file
-if [ -f "SHA256SUMS" ]; then
-  echo "Signing SHA256SUMS..."
+if [ -f "release-assets/SHA256SUMS" ]; then
+  echo "Signing release-assets/SHA256SUMS..."
   echo "$GPG_PASSPHRASE" | gpg \
     --batch \
     --yes \
@@ -59,16 +60,17 @@ if [ -f "SHA256SUMS" ]; then
     --armor \
     --detach-sign \
     --default-key "$KEY_ID" \
-    SHA256SUMS
+    --pinentry-mode loopback \
+    release-assets/SHA256SUMS
 
-  if [ -f "SHA256SUMS.asc" ]; then
-    echo "✅ SHA256SUMS signed successfully → SHA256SUMS.asc"
+  if [ -f "release-assets/SHA256SUMS.asc" ]; then
+    echo "✅ SHA256SUMS signed successfully → release-assets/SHA256SUMS.asc"
   else
-    echo "❌ ERROR: Failed to sign SHA256SUMS"
+    echo "❌ ERROR: Failed to sign release-assets/SHA256SUMS"
     exit 1
   fi
 else
-  echo "❌ ERROR: SHA256SUMS file not found"
+  echo "❌ ERROR: release-assets/SHA256SUMS file not found"
   exit 1
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,14 @@ jobs:
           echo "::endgroup::"
 
       # Phase 5: US4 - GitHub Integration
+      - name: Configure GPG
+        run: |
+          echo "use-agent" >> ~/.gnupg/gpg. conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" >> ~/. gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent
+          gpgconf --launch gpg-agent
+
       - name: Submit SBOM to GitHub Dependency Graph
         id: dependency-submission
         run: |
@@ -361,8 +369,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           SBOM_FILE: ${{ steps.sbom.outputs.sbom_file }}
         run: |
-          cd release-assets
-          ../.github/scripts/sign-artifacts.sh
+          .github/scripts/sign-artifacts.sh
 
       - name: Generate release notes
         run: |


### PR DESCRIPTION
Improve the GPG signing process by configuring the GPG agent to use loopback pinentry mode and updating the signing script to reference the correct SHA256SUMS file location. This ensures a smoother signing experience during the release workflow.