### PR TITLE
fix: preserve existing version manifest entries on release

### DIFF
--- a/.github/scripts/test_update_version_manifest.py
+++ b/.github/scripts/test_update_version_manifest.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""
+Unit tests for update-version-manifest.py
+
+Tests cover the following scenarios based on the contract specification:
+- Empty manifest: new version addition
+- Existing manifest: append new version while preserving existing entries
+- Duplicate version: update existing entry instead of creating a duplicate
+- isLatest flag: correctly updated across all entries
+- Version sorting: descending order
+- Validation: exactly one isLatest entry
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+# Add the script directory to the Python path
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Import the module under test (filename contains hyphens, so use importlib)
+import importlib
+update_version_manifest = importlib.import_module("update-version-manifest")
+
+
+class TestLoadManifest(unittest.TestCase):
+    """Tests for load_manifest function."""
+
+    def test_load_manifest_returns_empty_structure_when_file_does_not_exist(self):
+        """Given a non-existent file, should return empty versions list."""
+        non_existent = Path("/tmp/non_existent_manifest_test.json")
+        if non_existent.exists():
+            non_existent.unlink()
+        
+        result = update_version_manifest.load_manifest(non_existent)
+        self.assertEqual(result, {"versions": []})
+
+    def test_load_manifest_returns_existing_content(self):
+        """Given an existing manifest file, should return its content."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            
+            result = update_version_manifest.load_manifest(Path(f.name))
+            self.assertEqual(result, existing)
+            
+            Path(f.name).unlink()
+
+    def test_load_manifest_with_multiple_versions(self):
+        """Given a manifest with multiple versions, should return all versions."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v1.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-02-01T00:00:00Z"
+                    },
+                    {
+                        "version": "v1.0",
+                        "isLatest": False,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            
+            result = update_version_manifest.load_manifest(Path(f.name))
+            self.assertEqual(len(result["versions"]), 2)
+            
+            Path(f.name).unlink()
+
+
+class TestValidateManifest(unittest.TestCase):
+    """Tests for validate_manifest function."""
+
+    def test_validate_manifest_with_exactly_one_latest(self):
+        """Valid manifest with exactly one isLatest=True should pass."""
+        manifest = {
+            "versions": [
+                {"version": "v1.0", "isLatest": True, "publishedDate": "2026-01-01T00:00:00Z"}
+            ]
+        }
+        self.assertTrue(update_version_manifest.validate_manifest(manifest))
+
+    def test_validate_manifest_with_no_latest(self):
+        """Manifest with no isLatest=True should fail."""
+        manifest = {
+            "versions": [
+                {"version": "v1.0", "isLatest": False, "publishedDate": "2026-01-01T00:00:00Z"}
+            ]
+        }
+        self.assertFalse(update_version_manifest.validate_manifest(manifest))
+
+    def test_validate_manifest_with_multiple_latest(self):
+        """Manifest with multiple isLatest=True should fail."""
+        manifest = {
+            "versions": [
+                {"version": "v1.1", "isLatest": True, "publishedDate": "2026-02-01T00:00:00Z"},
+                {"version": "v1.0", "isLatest": True, "publishedDate": "2026-01-01T00:00:00Z"}
+            ]
+        }
+        self.assertFalse(update_version_manifest.validate_manifest(manifest))
+
+    def test_validate_manifest_missing_versions_key(self):
+        """Manifest without 'versions' key should fail."""
+        manifest = {}
+        self.assertFalse(update_version_manifest.validate_manifest(manifest))
+
+
+class TestUpdateManifest(unittest.TestCase):
+    """Tests for update_manifest function."""
+
+    def test_add_version_to_empty_manifest(self):
+        """Given empty manifest, should add the version as the first entry with isLatest=True."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({"versions": []}, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.1")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            self.assertEqual(len(result["versions"]), 1)
+            self.assertEqual(result["versions"][0]["version"], "v0.1")
+            self.assertTrue(result["versions"][0]["isLatest"])
+            self.assertIn("publishedDate", result["versions"][0])
+        finally:
+            manifest_path.unlink()
+
+    def test_add_version_to_existing_manifest_preserves_entries(self):
+        """Given manifest with v0.1, adding v0.2 should preserve v0.1 and add v0.2."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.2")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            self.assertEqual(len(result["versions"]), 2)
+            
+            # Both versions should be present
+            version_names = [v["version"] for v in result["versions"]]
+            self.assertIn("v0.1", version_names)
+            self.assertIn("v0.2", version_names)
+            
+            # v0.1 should still have its original publishedDate
+            v01 = next(v for v in result["versions"] if v["version"] == "v0.1")
+            self.assertEqual(v01["publishedDate"], "2026-01-01T00:00:00Z")
+        finally:
+            manifest_path.unlink()
+
+    def test_add_version_marks_new_as_latest_and_unmarks_old(self):
+        """Adding a new version should set isLatest=True for new and False for all existing."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.2")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            v01 = next(v for v in result["versions"] if v["version"] == "v0.1")
+            v02 = next(v for v in result["versions"] if v["version"] == "v0.2")
+            
+            self.assertFalse(v01["isLatest"])
+            self.assertTrue(v02["isLatest"])
+        finally:
+            manifest_path.unlink()
+
+    def test_duplicate_version_does_not_create_new_entry(self):
+        """Adding the same version again should update existing entry, not create a duplicate."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.2",
+                        "isLatest": True,
+                        "publishedDate": "2026-02-01T00:00:00Z"
+                    },
+                    {
+                        "version": "v0.1",
+                        "isLatest": False,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.2")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            # Should still have exactly 2 versions, not 3
+            self.assertEqual(len(result["versions"]), 2)
+            
+            # v0.2 should still be latest
+            v02 = next(v for v in result["versions"] if v["version"] == "v0.2")
+            self.assertTrue(v02["isLatest"])
+            
+            # v0.1 should not be latest
+            v01 = next(v for v in result["versions"] if v["version"] == "v0.1")
+            self.assertFalse(v01["isLatest"])
+        finally:
+            manifest_path.unlink()
+
+    def test_duplicate_version_updates_published_date(self):
+        """Re-running with the same version should update its publishedDate."""
+        original_date = "2026-01-15T00:00:00Z"
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.1",
+                        "isLatest": True,
+                        "publishedDate": original_date
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.1")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            v01 = next(v for v in result["versions"] if v["version"] == "v0.1")
+            # publishedDate should be updated (different from original)
+            self.assertNotEqual(v01["publishedDate"], original_date)
+        finally:
+            manifest_path.unlink()
+
+    def test_versions_sorted_descending(self):
+        """Versions should be sorted in descending order."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.2")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            version_names = [v["version"] for v in result["versions"]]
+            # v0.2 should come before v0.1 (descending)
+            self.assertEqual(version_names, ["v0.2", "v0.1"])
+        finally:
+            manifest_path.unlink()
+
+    def test_multiple_versions_sorted_correctly(self):
+        """Multiple versions should be sorted in correct descending order."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v1.1",
+                        "isLatest": True,
+                        "publishedDate": "2026-03-01T00:00:00Z"
+                    },
+                    {
+                        "version": "v1.0",
+                        "isLatest": False,
+                        "publishedDate": "2026-02-01T00:00:00Z"
+                    },
+                    {
+                        "version": "v0.1",
+                        "isLatest": False,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v2.0")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            version_names = [v["version"] for v in result["versions"]]
+            self.assertEqual(version_names, ["v2.0", "v1.1", "v1.0", "v0.1"])
+        finally:
+            manifest_path.unlink()
+
+    def test_output_is_valid_json_with_trailing_newline(self):
+        """Output file should be valid JSON with a trailing newline."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({"versions": []}, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.1")
+            
+            with open(manifest_path) as f:
+                content = f.read()
+            
+            # Should end with newline
+            self.assertTrue(content.endswith('\n'))
+            
+            # Should be valid JSON
+            parsed = json.loads(content)
+            self.assertIn("versions", parsed)
+        finally:
+            manifest_path.unlink()
+
+    def test_manifest_file_does_not_exist_creates_new(self):
+        """If manifest file doesn't exist, should create it with the new version."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "versions.json"
+            
+            update_version_manifest.update_manifest(manifest_path, "v0.1")
+            
+            self.assertTrue(manifest_path.exists())
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            self.assertEqual(len(result["versions"]), 1)
+            self.assertEqual(result["versions"][0]["version"], "v0.1")
+            self.assertTrue(result["versions"][0]["isLatest"])
+
+    def test_published_date_is_utc_iso_format(self):
+        """publishedDate should be in UTC ISO 8601 format ending with 'Z'."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({"versions": []}, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.1")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            published_date = result["versions"][0]["publishedDate"]
+            self.assertTrue(published_date.endswith("Z"))
+            
+            # Should be parseable as ISO 8601
+            datetime.fromisoformat(published_date.rstrip("Z"))
+        finally:
+            manifest_path.unlink()
+
+    def test_add_third_version_preserves_all_existing(self):
+        """Adding a third version to a manifest with two versions should preserve all three."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            existing = {
+                "versions": [
+                    {
+                        "version": "v0.2",
+                        "isLatest": True,
+                        "publishedDate": "2026-02-01T00:00:00Z"
+                    },
+                    {
+                        "version": "v0.1",
+                        "isLatest": False,
+                        "publishedDate": "2026-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            json.dump(existing, f)
+            f.flush()
+            manifest_path = Path(f.name)
+        
+        try:
+            update_version_manifest.update_manifest(manifest_path, "v0.3")
+            
+            with open(manifest_path) as f:
+                result = json.load(f)
+            
+            self.assertEqual(len(result["versions"]), 3)
+            
+            version_names = [v["version"] for v in result["versions"]]
+            self.assertIn("v0.1", version_names)
+            self.assertIn("v0.2", version_names)
+            self.assertIn("v0.3", version_names)
+            
+            # Only v0.3 should be latest
+            for v in result["versions"]:
+                if v["version"] == "v0.3":
+                    self.assertTrue(v["isLatest"])
+                else:
+                    self.assertFalse(v["isLatest"])
+        finally:
+            manifest_path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update-version-manifest.py
+++ b/.github/scripts/update-version-manifest.py
@@ -6,7 +6,7 @@ Maintains a JSON manifest of all published documentation versions.
 
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -42,13 +42,25 @@ def update_manifest(manifest_path: Path, new_version: str) -> None:
     for version in manifest["versions"]:
         version["isLatest"] = False
     
-    # Add new version
-    new_entry = {
-        "version": new_version,
-        "isLatest": True,
-        "publishedDate": datetime.utcnow().isoformat() + "Z"
-    }
-    manifest["versions"].append(new_entry)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+    
+    # Check if version already exists (idempotent update)
+    existing_versions = {v["version"] for v in manifest["versions"]}
+    if new_version in existing_versions:
+        # Update existing entry
+        for version in manifest["versions"]:
+            if version["version"] == new_version:
+                version["isLatest"] = True
+                version["publishedDate"] = now
+                break
+    else:
+        # Add new version entry
+        new_entry = {
+            "version": new_version,
+            "isLatest": True,
+            "publishedDate": now
+        }
+        manifest["versions"].append(new_entry)
     
     # Sort by version (descending)
     manifest["versions"].sort(key=lambda v: v["version"], reverse=True)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,6 +506,12 @@ jobs:
           docfx metadata
           docfx build --output _site/${{ steps.version.outputs.version }}
       
+      - name: Fetch existing version manifest from gh-pages
+        run: |
+          mkdir -p _site
+          git fetch origin gh-pages:gh-pages 2>/dev/null || true
+          git show gh-pages:versions.json > _site/versions.json 2>/dev/null || echo '{"versions": []}' > _site/versions.json
+
       - name: Update version manifest
         run: |
           python3 .github/scripts/update-version-manifest.py _site/versions.json ${{ steps.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ release-assets/
 _manifest/
 sbom-test.spdx.json
 
+# Python
+__pycache__/
+
 .env
 .mcp.json
 .serena/

--- a/specs/001-github-pages-docs/contracts/github-workflow-contract.md
+++ b/specs/001-github-pages-docs/contracts/github-workflow-contract.md
@@ -110,10 +110,37 @@ outputs:
 
 **Note**: Link validation and `--warningsAsErrors` flag are deferred to Phase 8 (Polish & Cross-Cutting Concerns) as quality improvements, not MVP requirements.
 
-### Step 4: Update Version Manifest
+### Step 4: Fetch Existing Version Manifest
 
-**Input**: New version from previous step
-**Output**: Updated `versions.json` in `_site/`  
+**Input**: `gh-pages` branch (may not exist on first release)
+**Output**: Existing `versions.json` placed at `_site/versions.json`
+**Contract**:
+
+```yaml
+- name: Fetch existing version manifest from gh-pages
+  run: |
+    mkdir -p _site
+    git fetch origin gh-pages:gh-pages 2>/dev/null || true
+    git show gh-pages:versions.json > _site/versions.json 2>/dev/null || echo '{"versions": []}' > _site/versions.json
+```
+
+**Validation**:
+
+- MUST attempt to fetch `versions.json` from `gh-pages` branch
+- MUST gracefully handle missing `gh-pages` branch (first release scenario)
+- MUST gracefully handle missing `versions.json` on `gh-pages` branch
+- MUST create empty manifest `{"versions": []}` when no existing manifest is found
+- MUST place the fetched or empty manifest at `_site/versions.json` before the update step
+
+**Rationale**:
+
+- The `peaceiris/actions-gh-pages` action's `keep_files: true` option only preserves existing files on `gh-pages` during deployment. It does NOT make previously deployed files available in the build workspace.
+- Without this explicit fetch step, the Python update script always starts from an empty manifest, causing previous version entries to be lost.
+
+### Step 5: Update Version Manifest
+
+**Input**: Existing manifest from Step 4, new version from Step 1
+**Output**: Updated `versions.json` in `_site/`
 **Contract**:
 
 ```yaml
@@ -130,7 +157,8 @@ outputs:
 - MUST remove `isLatest` from all other versions
 - MUST sort versions by version string (descending)
 - MUST automatically generate publishedDate with UTC timestamp
-- MUST be idempotent (re-running updates, doesn't duplicate)
+- MUST be idempotent (re-running with the same version updates the existing entry instead of creating a duplicate)
+- MUST preserve all existing version entries from the fetched manifest
 - MUST exit with code 0 on success
 
 **Python Script Contract** (`.github/scripts/update-version-manifest.py`):
@@ -139,12 +167,15 @@ outputs:
 # MUST accept positional arguments: <manifest_path> <version>
 # Usage: update-version-manifest.py <manifest_path> <version>
 # MUST read existing manifest from path (or create empty if missing)
+# MUST check for duplicate version entries before adding
+# MUST update existing entry (publishedDate, isLatest) if version already exists
+# MUST add new entry only if version does not already exist
 # MUST update/add version entry with auto-generated publishedDate
 # MUST write valid JSON output to same path
 # MUST exit 0 on success, non-zero on error
 ```
 
-### Step 5: Deploy to GitHub Pages
+### Step 6: Deploy to GitHub Pages
 
 **Input**: Built site in `_site/`  
 **Output**: Deployed documentation on GitHub Pages  
@@ -162,16 +193,11 @@ outputs:
 **Validation**:
 
 - MUST deploy entire `_site` directory
-- MUST preserve existing version directories (keep_files: true)
+- MUST preserve existing version directories (`keep_files: true`)
 - MUST use GITHUB_TOKEN for authentication
 - MUST exit with code 0 on successful deployment
 
-**Note**: The peaceiris/actions-gh-pages action handles manifest fetching internally through keep_files: true, eliminating the need for explicit gh-pages branch fetching.
-      --no-warnings \
-      _output/${{ steps.version.outputs.minor }}/
-
-```
-**Note**: The peaceiris/actions-gh-pages action handles manifest fetching internally through keep_files: true, eliminating the need for explicit gh-pages branch fetching.
+**Note**: The `keep_files: true` option preserves existing files on the `gh-pages` branch during deployment (e.g., previously deployed version directories). However, it does NOT make those files available in the build workspace. The explicit fetch step (Step 4) is required to retrieve the existing `versions.json` before the update step.
 
 ## Error Handling
 
@@ -182,6 +208,8 @@ outputs:
 | Command doc generation fails | Stop workflow, show error | 1 |
 | DocFX metadata generation fails | Stop workflow, show error | 1 |
 | DocFX build fails | Stop workflow, show build errors | 1 |
+| gh-pages branch not found | Non-fatal: fall back to empty manifest `{"versions": []}` | 0 |
+| versions.json not found on gh-pages | Non-fatal: fall back to empty manifest `{"versions": []}` | 0 |
 | Version manifest update fails | Stop workflow, show Python error | 1 |
 | GitHub Pages deployment fails | Handled by peaceiris action (auto-retry) | 1 |
 


### PR DESCRIPTION
## 概要

version manifest () がリリースのたびに新規作成されてしまい、過去のバージョン情報が失われる問題を修正します。

## 根本原因

`build-and-deploy-docs` ジョブで DocFX ビルド後に `_site/versions.json` を更新する際、`gh-pages` ブランチ上の既存 `versions.json` を取得していなかったため、毎回空のマニフェストから開始されていました。

`peaceiris/actions-gh-pages` の `keep_files: true` はデプロイ時に既存ファイルを保持しますが、ビルド前のワークスペースに取得する機能はありません。

## 変更内容

### ワークフロー (`.github/workflows/release.yml`)
- `gh-pages` ブランチから既存 `versions.json` を取得するステップを追加

### Python スクリプト (`.github/scripts/update-version-manifest.py`)
- 重複バージョン検出ロジックを追加（べき等性の確保）
- 非推奨の `datetime.utcnow()` → `datetime.now(timezone.utc)` に修正

### テスト (`.github/scripts/test_update_version_manifest.py`)
- 18件のユニットテストを追加（空マニフェスト追加、既存追記、重複検出、isLatest更新、ソート、バリデーション等）

### 仕様書 (`specs/001-github-pages-docs/contracts/github-workflow-contract.md`)
- 「Fetch Existing Version Manifest」ステップ (Step 4) を追加
- `keep_files: true` に関する誤った注記を修正
- Error Handling テーブルに非致命的エラーケースを追加

### その他
- `.gitignore` に `__pycache__/` を追加

## テスト結果

```
Ran 18 tests in 0.005s
OK
```