### PR TITLE
fix: resolve overlapping glob patterns in release asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,8 +437,9 @@ jobs:
           prerelease: false
           files: |
             release-assets/wtm-*-windows-*.exe
-            release-assets/wtm-*-linux-*
-            release-assets/wtm-*-macos-*
+            release-assets/wtm-*-linux-x64
+            release-assets/wtm-*-linux-arm
+            release-assets/wtm-*-macos-arm64
             release-assets/*.sha256
             release-assets/wtm-*-sbom.spdx.json
             release-assets/wtm-*-sbom.spdx.json.asc


### PR DESCRIPTION
## Summary

- `wtm-*-linux-*` と `wtm-*-macos-*` のワイルドカードパターンが `.sha256` ファイルにもマッチし、一部アセットが2回アップロードされていた
- 2回目のアップロード時に `Not Found` エラーが発生し、リリースワークフローが失敗していた
- Linux/macOS バイナリのパターンをアーキテクチャ名を明示した形式に変更し、重複マッチを解消

## Changes

`.github/workflows/release.yml` の `Create GitHub Release` ステップ:

| 変更前 | 変更後 |
|--------|--------|
| `wtm-*-linux-*` | `wtm-*-linux-x64` + `wtm-*-linux-arm` |
| `wtm-*-macos-*` | `wtm-*-macos-arm64` |

## Test plan

- [ ] `workflow_dispatch` でリリースワークフローを手動実行し、全アセットが1回ずつ正常にアップロードされることを確認
- [ ] `Create GitHub Release` ステップのログに重複アップロードや `Not Found` エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)